### PR TITLE
Sync health and work priority data

### DIFF
--- a/PhiData/RealmData.cs
+++ b/PhiData/RealmData.cs
@@ -12,7 +12,7 @@ namespace PhiClient
     [Serializable]
     public class RealmData
     {
-        public const string VERSION = "0.11";
+        public const string VERSION = "0.12";
 		public const int CHAT_MESSAGES_TO_SEND = 30;
         public const int CHAT_MESSAGE_MAX_LENGTH = 250;
 

--- a/PhiData/RealmPawn.cs
+++ b/PhiData/RealmPawn.cs
@@ -274,7 +274,7 @@ namespace PhiClient
                 if (!float.IsNaN(hediff.immunity) && !pawn.health.immunity.ImmunityRecordExists(definition))
                 {
                     var handler = pawn.health.immunity;
-                    handler.GetType().GetMethod("TryAddImmunityRecord").Invoke(handler, new object[] { definition });
+                    handler.GetType().GetMethod("TryAddImmunityRecord", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance).Invoke(handler, new object[] { definition });
                     var record = handler.GetImmunityRecord(definition);
                     record.immunity = hediff.immunity;
                 }

--- a/PhiData/RealmPawn.cs
+++ b/PhiData/RealmPawn.cs
@@ -93,6 +93,11 @@ namespace PhiClient
 
                 var immunity = pawn.health.immunity.GetImmunityRecord(hediff.def);
 
+                Debug.Log(String.Format("Bodypart: {0}", hediff.Part.def.defName));
+                if (!pawn.RaceProps.body.AllParts.Contains(hediff.Part)) {
+                    continue;
+                }
+
                 hediffs.Add(new RealmHediff(){
                     hediffDefName = hediff.def.defName,
                     bodyPartIndex = pawn.RaceProps.body.GetIndexOfPart(hediff.Part),
@@ -235,7 +240,7 @@ namespace PhiClient
 
                 pawn.health.AddHediff(definition, bodypart);
 
-                if (!pawn.health.immunity.ImmunityRecordExists(definition))
+                if (!float.IsNaN(hediff.immunity) && !pawn.health.immunity.ImmunityRecordExists(definition))
                 {
                     var handler = pawn.health.immunity;
                     handler.GetType().GetMethod("TryAddImmunityRecord").Invoke(handler, new object[] { definition });


### PR DESCRIPTION
Sends health and work priority data along with colonist transfers. Fixes #15 

I can't make this backwards compatible so I had to bump the version number.

## Testing
1. Build branch or download the compiled version from https://delftelectronics.nl/3-PhiData.dll
2. Replace the existing 3-PhiData.dll file in your mod folder (`<steamlibrary>/steamapps/workshop/content/294100/732930564/Assemblies/3-PhiData.dll`)
3. Replace the existing 3-PhiData.dll file in your server folder
4. Injure your colonists
5. Feel bad and adjust work priorities
6. Send colonist somewhere else
7. See that injuries and work priorities transfer along
