### PR TITLE
Authentication Upgrade & Spam Fix

### DIFF
--- a/PhiClient/PhiClient.cs
+++ b/PhiClient/PhiClient.cs
@@ -108,6 +108,8 @@ namespace PhiClient
                 this.realmData.PacketToServer += PacketToServerCallback;
                 this.realmData.Log += Log;
 
+                SaveCredentials();
+
                 if (OnUsable != null)
                 {
                     OnUsable();
@@ -117,6 +119,21 @@ namespace PhiClient
             {
                 packet.Apply(this.currentUser, this.realmData);
             }
+        }
+
+        private void SaveCredentials()
+        {
+            string key;
+            if (File.Exists(KEY_FILE))
+            {
+                key = File.ReadAllLines(KEY_FILE)[0];
+            }
+            else
+            {
+                key = GetAuthKey();
+            }
+
+            File.WriteAllLines(KEY_FILE, new string[] { key, currentUser.id.ToString() });
         }
 
         private void Log(LogLevel level, string message)
@@ -157,7 +174,8 @@ namespace PhiClient
 
             string nickname = SteamUtility.SteamPersonaName;
             string hashedKey = GetHashedAuthKey();
-            this.SendPacket(new AuthentificationPacket { name = nickname, hashedKey = hashedKey, version = RealmData.VERSION });
+            int? id = GetId();
+            this.SendPacket(new AuthentificationPacket { name = nickname, id = id, hashedKey = hashedKey, version = RealmData.VERSION });
             Log(LogLevel.INFO, "Trying to authenticate as " + nickname);
         }
 
@@ -192,6 +210,22 @@ namespace PhiClient
 
                 File.WriteAllLines(KEY_FILE, new string[] { key });
                 return key;
+            }
+        }
+
+        private int? GetId()
+        {
+            if (File.Exists(KEY_FILE))
+            {
+                if (File.ReadAllLines(KEY_FILE).Length > 1)
+                {
+                    return int.Parse(File.ReadAllLines(KEY_FILE)[1]);
+                }
+                else return null;
+            }
+            else
+            {
+                return null;
             }
         }
 
@@ -259,7 +293,7 @@ namespace PhiClient
 
                 realmThings.Add(new KeyValuePair<RealmThing, int>(realmThing, entry.Value));
             }
-
+            
             int id = ++this.currentUser.lastTransactionId;
             ItemTransaction transaction = new ItemTransaction(id, currentUser, user, chosenThings, realmThings);
             realmData.transactions.Add(transaction);

--- a/PhiData/Packet.cs
+++ b/PhiData/Packet.cs
@@ -42,6 +42,7 @@ namespace PhiClient
     public class AuthentificationPacket : Packet
     {
         public string name;
+        public int? id;
         public string hashedKey;
         public string version;
 

--- a/PhiData/RealmData.cs
+++ b/PhiData/RealmData.cs
@@ -111,22 +111,19 @@ namespace PhiClient
             }
         }
 
-        public User ServerAddUser(string name, string hashKey)
+        public User ServerAddUser(string name, int id)
         {
-            this.lastUserGivenId++;
-            int id = this.lastUserGivenId;
 
             User user = new User
             {
                 id = id,
                 name = name,
                 connected = true,
-                inGame = false,
-                hashedKey = hashKey
+                inGame = false
             };
 
             AddUser(user);
-            EmitLog(LogLevel.INFO, string.Format("Created user {0} ({1})", name, hashKey));
+            EmitLog(LogLevel.INFO, string.Format("Created user {0} ({1})", name, id));
 
             return user;
         }

--- a/PhiData/RealmData.cs
+++ b/PhiData/RealmData.cs
@@ -12,7 +12,7 @@ namespace PhiClient
     [Serializable]
     public class RealmData
     {
-        public const string VERSION = "0.12";
+        public const string VERSION = "0.14";
 		public const int CHAT_MESSAGES_TO_SEND = 30;
         public const int CHAT_MESSAGE_MAX_LENGTH = 250;
 

--- a/PhiData/RealmData.cs
+++ b/PhiData/RealmData.cs
@@ -122,7 +122,7 @@ namespace PhiClient
                 name = name,
                 connected = true,
                 inGame = false,
-                hashedKey= hashKey
+                hashedKey = hashKey
             };
 
             AddUser(user);

--- a/PhiData/TransactionSystem/AnimalTransaction.cs
+++ b/PhiData/TransactionSystem/AnimalTransaction.cs
@@ -78,6 +78,10 @@ namespace PhiClient.TransactionSystem
             {
                 Messages.Message("Unexpected interruption during item transaction with " + sender.name, MessageTypeDefOf.RejectInput);
             }
+            else if (state == TransactionResponse.TOOFAST)
+            {
+                // This should never happen as the server rejects intercepted packets.
+            }
         }
 
         public override void OnEndSender(RealmData realmData)
@@ -94,6 +98,10 @@ namespace PhiClient.TransactionSystem
             else if (state == TransactionResponse.INTERRUPTED)
             {
                 Messages.Message("Unexpected interruption during item transaction with " + receiver.name, MessageTypeDefOf.RejectInput);
+            }
+            else if (state == TransactionResponse.TOOFAST)
+            {
+                Messages.Message("Transaction with " + receiver.name + " was declined by the server. Are you sending animals too quickly?", MessageTypeDefOf.RejectInput);
             }
         }
     }

--- a/PhiData/TransactionSystem/AnimalTransaction.cs
+++ b/PhiData/TransactionSystem/AnimalTransaction.cs
@@ -23,8 +23,19 @@ namespace PhiClient.TransactionSystem
 
         public override void OnStartReceiver(RealmData realmData)
         {
+            // Double check to ensure it wasn't bypassed by the sender
+            if (!receiver.preferences.receiveAnimals)
+            {
+                realmData.NotifyPacketToServer(new ConfirmServerTransactionPacket
+                {
+                    transaction = this,
+                    response = TransactionResponse.DECLINED
+                });
+                return;
+            }
+
             // We ask for confirmation
-            
+
             Dialog_GeneralChoice choiceDialog = new Dialog_GeneralChoice(new DialogChoiceConfig
             {
                 text = sender.name + " wants to send you a " + realmAnimal.FromRealmAnimal(realmData).kindDef.label,
@@ -53,6 +64,17 @@ namespace PhiClient.TransactionSystem
 
         public override void OnEndReceiver(RealmData realmData)
         {
+            // Double check to ensure it wasn't bypassed by the sender
+            if (!receiver.preferences.receiveAnimals)
+            {
+                realmData.NotifyPacketToServer(new ConfirmServerTransactionPacket
+                {
+                    transaction = this,
+                    response = TransactionResponse.DECLINED
+                });
+                return;
+            }
+
             // Nothing
             if (state == TransactionResponse.ACCEPTED)
             {

--- a/PhiData/TransactionSystem/ColonistTransaction.cs
+++ b/PhiData/TransactionSystem/ColonistTransaction.cs
@@ -95,7 +95,7 @@ namespace PhiClient.TransactionSystem
             {
                 Messages.Message("Unexpected interruption during item transaction with " + sender.name, MessageTypeDefOf.RejectInput);
             }
-            else if (state == TransactionResponse.INTERCEPTED)
+            else if (state == TransactionResponse.TOOFAST)
             {
                 // This should never happen as the server rejects intercepted packets.
             }
@@ -122,7 +122,7 @@ namespace PhiClient.TransactionSystem
             {
                 Messages.Message("Unexpected interruption during item transaction with " + receiver.name, MessageTypeDefOf.RejectInput);
             }
-            else if (state == TransactionResponse.INTERCEPTED)
+            else if (state == TransactionResponse.TOOFAST)
             {
                 Messages.Message("Transaction with " + receiver.name + " was declined by the server. Are you sending colonists too quickly?", MessageTypeDefOf.RejectInput);
             }

--- a/PhiData/TransactionSystem/ColonistTransaction.cs
+++ b/PhiData/TransactionSystem/ColonistTransaction.cs
@@ -23,8 +23,18 @@ namespace PhiClient.TransactionSystem
 
         public override void OnStartReceiver(RealmData realmData)
         {
+            // Double check to ensure it wasn't bypassed by the sender
+            if (!receiver.preferences.receiveColonists)
+            {
+                realmData.NotifyPacketToServer(new ConfirmServerTransactionPacket
+                {
+                    transaction = this,
+                    response = TransactionResponse.DECLINED
+                });
+            }
+
             // We ask for confirmation
-            
+
             Dialog_GeneralChoice choiceDialog = new Dialog_GeneralChoice(new DialogChoiceConfig
             {
                 text = sender.name + " wants to send you a colonist",

--- a/PhiData/TransactionSystem/ColonistTransaction.cs
+++ b/PhiData/TransactionSystem/ColonistTransaction.cs
@@ -78,6 +78,10 @@ namespace PhiClient.TransactionSystem
             {
                 Messages.Message("Unexpected interruption during item transaction with " + sender.name, MessageTypeDefOf.RejectInput);
             }
+            else if (state == TransactionResponse.INTERCEPTED)
+            {
+                // This should never happen as the server rejects intercepted packets.
+            }
         }
 
         public override void OnEndSender(RealmData realmData)
@@ -94,6 +98,10 @@ namespace PhiClient.TransactionSystem
             else if (state == TransactionResponse.INTERRUPTED)
             {
                 Messages.Message("Unexpected interruption during item transaction with " + receiver.name, MessageTypeDefOf.RejectInput);
+            }
+            else if (state == TransactionResponse.INTERCEPTED)
+            {
+                Messages.Message("Transaction with " + receiver.name + " was declined by the server. Are you sending colonists too quickly?", MessageTypeDefOf.RejectInput);
             }
         }
     }

--- a/PhiData/TransactionSystem/ColonistTransaction.cs
+++ b/PhiData/TransactionSystem/ColonistTransaction.cs
@@ -31,6 +31,7 @@ namespace PhiClient.TransactionSystem
                     transaction = this,
                     response = TransactionResponse.DECLINED
                 });
+                return;
             }
 
             // We ask for confirmation
@@ -63,6 +64,12 @@ namespace PhiClient.TransactionSystem
 
         public override void OnEndReceiver(RealmData realmData)
         {
+            // Double check to ensure it wasn't bypassed by the sender
+            if (!receiver.preferences.receiveItems)
+            {
+                state = TransactionResponse.DECLINED;
+            }
+
             // Nothing
             if (state == TransactionResponse.ACCEPTED)
             {
@@ -96,6 +103,12 @@ namespace PhiClient.TransactionSystem
 
         public override void OnEndSender(RealmData realmData)
         {
+            // Double check to ensure it wasn't bypassed by the sender
+            if (!receiver.preferences.receiveItems)
+            {
+                state = TransactionResponse.DECLINED;
+            }
+
             if (state == TransactionResponse.ACCEPTED)
             {
                 pawn.Destroy();

--- a/PhiData/TransactionSystem/ConfirmServerTransactionPacket.cs
+++ b/PhiData/TransactionSystem/ConfirmServerTransactionPacket.cs
@@ -7,7 +7,7 @@ using System.Text;
 namespace PhiClient.TransactionSystem
 {
     /// <summary>
-    /// Received by the server
+    /// Received by the server from the recipient
     /// </summary>
     [Serializable]
     public class ConfirmServerTransactionPacket : Packet
@@ -26,9 +26,16 @@ namespace PhiClient.TransactionSystem
             }
             transaction.state = response;
 
-            // We signal to the 2 users that the transaction is now confirmed
-            realmData.NotifyPacket(transaction.sender, new ConfirmTransactionPacket { transaction = transaction, response = response, toSender = true });
-            realmData.NotifyPacket(transaction.receiver, new ConfirmTransactionPacket { transaction = transaction, response = response });
+            if (user == transaction.receiver)
+            {
+                // We signal to the 2 users that the transaction is now confirmed
+                realmData.NotifyPacket(transaction.sender, new ConfirmTransactionPacket { transaction = transaction, response = response, toSender = true });
+                realmData.NotifyPacket(transaction.receiver, new ConfirmTransactionPacket { transaction = transaction, response = response });
+            }
+            else
+            {
+                // Fraudulent confirmation, take no action
+            }
         }
 
         [OnSerializing]

--- a/PhiData/TransactionSystem/ConfirmServerTransactionPacket.cs
+++ b/PhiData/TransactionSystem/ConfirmServerTransactionPacket.cs
@@ -24,22 +24,16 @@ namespace PhiClient.TransactionSystem
             {
                 return;
             }
+
             if (transaction.state != TransactionResponse.WAITING)
             {
                 return;
             }
             transaction.state = response;
 
-            if (user == transaction.receiver)
-            {
-                // We signal to the 2 users that the transaction is now confirmed
-                realmData.NotifyPacket(transaction.sender, new ConfirmTransactionPacket { transaction = transaction, response = response, toSender = true });
-                realmData.NotifyPacket(transaction.receiver, new ConfirmTransactionPacket { transaction = transaction, response = response });
-            }
-            else
-            {
-                // Fraudulent confirmation, take no action
-            }
+            // We signal to the 2 users that the transaction is now confirmed
+            realmData.NotifyPacket(transaction.sender, new ConfirmTransactionPacket { transaction = transaction, response = response, toSender = true });
+            realmData.NotifyPacket(transaction.receiver, new ConfirmTransactionPacket { transaction = transaction, response = response });
         }
 
         [OnSerializing]

--- a/PhiData/TransactionSystem/ItemTransaction.cs
+++ b/PhiData/TransactionSystem/ItemTransaction.cs
@@ -94,6 +94,10 @@ namespace PhiClient.TransactionSystem
             {
                 Messages.Message("Unexpected interruption during item transaction with " + sender.name, MessageTypeDefOf.RejectInput);
             }
+            else if (state == TransactionResponse.INTERCEPTED)
+            {
+                // This should never happen as the server rejects intercepted packets
+            }
         }
 
         public override void OnEndSender(RealmData realmData)
@@ -142,6 +146,10 @@ namespace PhiClient.TransactionSystem
             else if (state == TransactionResponse.INTERRUPTED)
             {
                 Messages.Message("Unexpected interruption during item transaction with " + receiver.name, MessageTypeDefOf.RejectInput);
+            }
+            else if (state == TransactionResponse.INTERCEPTED)
+            {
+                Messages.Message("Transaction with " + receiver.name + " was declined by the server. Are you sending items too quickly?", MessageTypeDefOf.RejectInput);
             }
         }
     }

--- a/PhiData/TransactionSystem/ItemTransaction.cs
+++ b/PhiData/TransactionSystem/ItemTransaction.cs
@@ -23,6 +23,16 @@ namespace PhiClient.TransactionSystem
 
         public override void OnStartReceiver(RealmData realmData)
         {
+            // Double check to ensure it wasn't bypassed by the sender
+            if (!receiver.preferences.receiveItems)
+            {
+                realmData.NotifyPacketToServer(new ConfirmServerTransactionPacket
+                {
+                    transaction = this,
+                    response = TransactionResponse.DECLINED
+                });
+            }
+
             // We generate a detailed list of what the pack contains
             List<KeyValuePair<Thing, int>> things = realmThings.Select((r) => new KeyValuePair<Thing, int>(realmData.FromRealmThing(r.Key), r.Value)).ToList();
 

--- a/PhiData/TransactionSystem/ItemTransaction.cs
+++ b/PhiData/TransactionSystem/ItemTransaction.cs
@@ -31,6 +31,7 @@ namespace PhiClient.TransactionSystem
                     transaction = this,
                     response = TransactionResponse.DECLINED
                 });
+                return;
             }
 
             // We generate a detailed list of what the pack contains
@@ -67,6 +68,12 @@ namespace PhiClient.TransactionSystem
 
         public override void OnEndReceiver(RealmData realmData)
         {
+            // Double check to ensure it wasn't bypassed by the sender
+            if (!receiver.preferences.receiveItems)
+            {
+                state = TransactionResponse.DECLINED;
+            }
+
             if (state == TransactionResponse.ACCEPTED)
             {
                 // We spawn the new items !
@@ -112,6 +119,12 @@ namespace PhiClient.TransactionSystem
 
         public override void OnEndSender(RealmData realmData)
         {
+            // Double check to ensure it wasn't bypassed by the sender
+            if (!receiver.preferences.receiveItems)
+            {
+                state = TransactionResponse.DECLINED;
+            }
+
             if (state == TransactionResponse.ACCEPTED)
             {
                 foreach (KeyValuePair<List<Thing>, int> entry in things)

--- a/PhiData/TransactionSystem/ItemTransaction.cs
+++ b/PhiData/TransactionSystem/ItemTransaction.cs
@@ -111,7 +111,7 @@ namespace PhiClient.TransactionSystem
             {
                 Messages.Message("Unexpected interruption during item transaction with " + sender.name, MessageTypeDefOf.RejectInput);
             }
-            else if (state == TransactionResponse.INTERCEPTED)
+            else if (state == TransactionResponse.TOOFAST)
             {
                 // This should never happen as the server rejects intercepted packets
             }
@@ -170,7 +170,7 @@ namespace PhiClient.TransactionSystem
             {
                 Messages.Message("Unexpected interruption during item transaction with " + receiver.name, MessageTypeDefOf.RejectInput);
             }
-            else if (state == TransactionResponse.INTERCEPTED)
+            else if (state == TransactionResponse.TOOFAST)
             {
                 Messages.Message("Transaction with " + receiver.name + " was declined by the server. Are you sending items too quickly?", MessageTypeDefOf.RejectInput);
             }

--- a/PhiData/TransactionSystem/StartTransactionPacket.cs
+++ b/PhiData/TransactionSystem/StartTransactionPacket.cs
@@ -17,6 +17,7 @@ namespace PhiClient.TransactionSystem
         {
             realmData.transactions.Add(transaction);
             user.lastTransactionId = transaction.id;
+            user.lastTransactionTime = DateTime.Now;
 
             realmData.NotifyPacket(transaction.receiver, new ReceiveTransactionPacket { transaction = transaction });
         }

--- a/PhiData/TransactionSystem/Transaction.cs
+++ b/PhiData/TransactionSystem/Transaction.cs
@@ -42,7 +42,8 @@ namespace PhiClient.TransactionSystem
         {
             return state == TransactionResponse.ACCEPTED
                 || state == TransactionResponse.DECLINED
-                || state == TransactionResponse.INTERRUPTED;
+                || state == TransactionResponse.INTERRUPTED
+                || state == TransactionResponse.INTERCEPTED;
         }
 
         [OnSerializing]
@@ -71,6 +72,7 @@ namespace PhiClient.TransactionSystem
         WAITING,
         ACCEPTED,
         DECLINED,
-        INTERRUPTED
+        INTERRUPTED,
+        INTERCEPTED
     }
 }

--- a/PhiData/TransactionSystem/Transaction.cs
+++ b/PhiData/TransactionSystem/Transaction.cs
@@ -43,7 +43,7 @@ namespace PhiClient.TransactionSystem
             return state == TransactionResponse.ACCEPTED
                 || state == TransactionResponse.DECLINED
                 || state == TransactionResponse.INTERRUPTED
-                || state == TransactionResponse.INTERCEPTED;
+                || state == TransactionResponse.TOOFAST;
         }
 
         [OnSerializing]
@@ -73,6 +73,6 @@ namespace PhiClient.TransactionSystem
         ACCEPTED,
         DECLINED,
         INTERRUPTED,
-        INTERCEPTED
+        TOOFAST
     }
 }

--- a/PhiData/User.cs
+++ b/PhiData/User.cs
@@ -19,6 +19,7 @@ namespace PhiClient
         public UserPreferences preferences = new UserPreferences();
 
         public int lastTransactionId = 0;
+        public DateTime lastTransactionTime = DateTime.MinValue;
 
         public int getID()
         {

--- a/PhiData/User.cs
+++ b/PhiData/User.cs
@@ -13,7 +13,6 @@ namespace PhiClient
 
         public int id;
         public string name;
-        public string hashedKey;
         public bool connected;
         public bool inGame;
         public UserPreferences preferences = new UserPreferences();

--- a/PhiServer/Program.cs
+++ b/PhiServer/Program.cs
@@ -185,7 +185,7 @@ namespace PhiServer
                     {
                         // Intercept the packet, returning it to sender
                         StartTransactionPacket transactionPacket = packet as StartTransactionPacket;
-                        transactionPacket.transaction.state = TransactionResponse.INTERCEPTED;
+                        transactionPacket.transaction.state = TransactionResponse.TOOFAST;
                         this.SendPacket(client, user, new ConfirmTransactionPacket { response = transactionPacket.transaction.state, toSender = true, transaction = transactionPacket.transaction});
 
                         // Report the packet to the log

--- a/PhiServer/Program.cs
+++ b/PhiServer/Program.cs
@@ -211,7 +211,7 @@ namespace PhiServer
         private int RegisterUserKey(int id, string hashedKey)
         {
             // Check if this user exists
-            if (userKeys.ContainsKey(id))
+            if (userKeys.ContainsKey(id) && id <= realmData.lastUserGivenId)
             {
                 // Check if the two keys are different
                 if (hashedKey != userKeys[id])

--- a/PhiServer/Program.cs
+++ b/PhiServer/Program.cs
@@ -126,35 +126,31 @@ namespace PhiServer
                     }
 
                     // Check if the user wants to use a specific id
+                    int userId;
                     if (authPacket.id != null)
                     {
                         // Link key to existing id, or a new one if it doesn't exist or the keys don't match
-                        RegisterUserKey(authPacket.id.Value, authPacket.hashedKey);
-                        user = this.realmData.users.FindLast(delegate (User u) { return u.id == authPacket.id; });
+                        userId = RegisterUserKey(authPacket.id.Value, authPacket.hashedKey);
                     }
                     else
                     {
                         // Generate a new id and link the key to it
-                        RegisterUserKey(++realmData.lastUserGivenId, authPacket.hashedKey);
+                        userId = RegisterUserKey(++realmData.lastUserGivenId, authPacket.hashedKey);
                     }
 
-                    bool newUser = false;
+                    user = this.realmData.users.FindLast(delegate (User u) { return userId == u.id; });
                     if (user == null)
                     {
-                        // Create the new user
-                        user = this.realmData.ServerAddUser(authPacket.name, realmData.lastUserGivenId);
-                        newUser = true;
-                    }
+                        user = this.realmData.ServerAddUser(authPacket.name, userId);
+                        user.connected = true;
 
-                    user.connected = true;
-
-                    if (newUser)
-                    {
                         // We send a notify to all users connected about the new user
                         this.realmData.BroadcastPacketExcept(new NewUserPacket { user = user }, user);
                     }
                     else
                     {
+                        user.connected = true;
+
                         // We send a connect notification to all users
                         this.realmData.BroadcastPacketExcept(new UserConnectedPacket { user = user, connected = true }, user);
                     }

--- a/PhiServer/Program.cs
+++ b/PhiServer/Program.cs
@@ -13,6 +13,7 @@ namespace PhiServer
         private Server server;
         private RealmData realmData;
         private Dictionary<ServerClient, User> connectedUsers = new Dictionary<ServerClient, User>();
+        private Dictionary<int, string> userKeys = new Dictionary<int, string>();
         private LogLevel logLevel;
 
         private object lockProcessPacket = new object();
@@ -102,7 +103,7 @@ namespace PhiServer
         {
             lock (lockProcessPacket)
 			{
-				User user;
+			    User user;
 				this.connectedUsers.TryGetValue(client, out user);
 
 				Packet packet = Packet.Deserialize(data, realmData, user);
@@ -124,25 +125,42 @@ namespace PhiServer
                         return;
                     }
 
-                    // We check if an user already uses this key
-                    user = this.realmData.users.FindLast(delegate (User u) { return u.hashedKey == authPacket.hashedKey; });
+                    // Check if the user wants to use a specific id
+                    if (authPacket.id != null)
+                    {
+                        // Link key to existing id, or a new one if it doesn't exist or the keys don't match
+                        RegisterUserKey(authPacket.id.Value, authPacket.hashedKey);
+                        user = this.realmData.users.FindLast(delegate (User u) { return u.id == authPacket.id; });
+                    }
+                    else
+                    {
+                        // Generate a new id and link the key to it
+                        RegisterUserKey(++realmData.lastUserGivenId, authPacket.hashedKey);
+                    }
+
+                    bool newUser = false;
                     if (user == null)
                     {
-                        user = this.realmData.ServerAddUser(authPacket.name, authPacket.hashedKey);
-                        user.connected = true;
+                        // Create the new user
+                        user = this.realmData.ServerAddUser(authPacket.name, realmData.lastUserGivenId);
+                        newUser = true;
+                    }
 
+                    user.connected = true;
+
+                    if (newUser)
+                    {
                         // We send a notify to all users connected about the new user
                         this.realmData.BroadcastPacketExcept(new NewUserPacket { user = user }, user);
                     }
                     else
                     {
                         // We send a connect notification to all users
-                        user.connected = true;
                         this.realmData.BroadcastPacketExcept(new UserConnectedPacket { user = user, connected = true }, user);
                     }
 
                     this.connectedUsers.Add(client, user);
-                    Log(LogLevel.INFO, string.Format("Client {0} connected as {1} ({2})", client.ID, user.name, user.hashedKey));
+                    Log(LogLevel.INFO, string.Format("Client {0} connected as {1} ({2})", client.ID, user.name, user.id));
 
                     // We respond with a StatePacket that contains all synchronisation data
                     this.SendPacket(client, user, new SynchronisationPacket { user = user, realmData = this.realmData });
@@ -187,6 +205,34 @@ namespace PhiServer
                     packet.Apply(user, this.realmData);
                 }
             }
+        }
+
+        /// <summary>
+        /// Checks if the key matches an existing id. If it does not match, returns new id which the key is linked to. Returns the input id otherwise.
+        /// </summary>
+        /// <param name="id">The user's id</param>
+        /// <param name="hashedKey">The user's hashed key. This should only be kept on the server.</param>
+        private int RegisterUserKey(int id, string hashedKey)
+        {
+            // Check if this user exists
+            if (userKeys.ContainsKey(id))
+            {
+                // Check if the two keys are different
+                if (hashedKey != userKeys[id])
+                {
+                    // Register a new id and key pair
+                    id = ++realmData.lastUserGivenId;
+                    userKeys.Add(id, hashedKey);
+                }
+            }
+            else
+            {
+                // Register a new id and key pair
+                id = ++realmData.lastUserGivenId;
+                userKeys.Add(id, hashedKey);
+            }
+
+            return id;
         }
 
         static void Main(string[] args)


### PR DESCRIPTION
## Description
This is a reworked and more secure version of the current username/key authentication system which solves two issues:

1. Fixes #29 by limiting transactions to one every three seconds for each user

2. Hashed keys are no longer distributed to clients, preventing attackers from pulling them from the user list and posing as other users

## New Auth Process
Authentication is now essentially a username and password based login, using the existing implementation of user ids and hashed keys. Each user is already assigned a unique id, so I moved the authentication system from checking the hashed key (and more recently the username) to checking both the user's id and hashed key.

When a user attempts to connect, they provide their hashed key and optionally a user id. If a user id is provided, the server checks whether that user id exists and whether the key matches. If either of these checks fail, the user is registered with a new id and their key is assigned to it. If a user id is not provided they follow the aforementioned registration process. The remainder of the authentication process remains the same. The user's hashed key is only stored in memory on the server and never propagated to other users.

## Summarised Changes
- Clients now use their id and hashed key as a username and password respectively
- Clients store their id alongside their key in the phikey.txt file
- Hashed keys are no longer propagated to other clients, instead they are stored in memory on the server
- Clients check if transactions contradict their preferences
- `User` objects record the last time a transaction was made
- Transactions are declined by the server if sent less than three seconds apart
- Updated realm data version

**Please don't hesitate to make comments or suggestions on the auth process or other details that I may have missed**