### PR TITLE
Remove user id requirement from authentication process

### DIFF
--- a/PhiClient/PhiClient.cs
+++ b/PhiClient/PhiClient.cs
@@ -108,8 +108,6 @@ namespace PhiClient
                 this.realmData.PacketToServer += PacketToServerCallback;
                 this.realmData.Log += Log;
 
-                SaveCredentials();
-
                 if (OnUsable != null)
                 {
                     OnUsable();
@@ -119,21 +117,6 @@ namespace PhiClient
             {
                 packet.Apply(this.currentUser, this.realmData);
             }
-        }
-
-        private void SaveCredentials()
-        {
-            string key;
-            if (File.Exists(KEY_FILE))
-            {
-                key = File.ReadAllLines(KEY_FILE)[0];
-            }
-            else
-            {
-                key = GetAuthKey();
-            }
-
-            File.WriteAllLines(KEY_FILE, new string[] { key, currentUser.id.ToString() });
         }
 
         private void Log(LogLevel level, string message)

--- a/PhiClient/PhiClient.cs
+++ b/PhiClient/PhiClient.cs
@@ -157,8 +157,7 @@ namespace PhiClient
 
             string nickname = SteamUtility.SteamPersonaName;
             string hashedKey = GetHashedAuthKey();
-            int? id = GetId();
-            this.SendPacket(new AuthentificationPacket { name = nickname, id = id, hashedKey = hashedKey, version = RealmData.VERSION });
+            this.SendPacket(new AuthentificationPacket { name = nickname, hashedKey = hashedKey, version = RealmData.VERSION });
             Log(LogLevel.INFO, "Trying to authenticate as " + nickname);
         }
 
@@ -193,22 +192,6 @@ namespace PhiClient
 
                 File.WriteAllLines(KEY_FILE, new string[] { key });
                 return key;
-            }
-        }
-
-        private int? GetId()
-        {
-            if (File.Exists(KEY_FILE))
-            {
-                if (File.ReadAllLines(KEY_FILE).Length > 1)
-                {
-                    return int.Parse(File.ReadAllLines(KEY_FILE)[1]);
-                }
-                else return null;
-            }
-            else
-            {
-                return null;
             }
         }
 

--- a/PhiData/Packet.cs
+++ b/PhiData/Packet.cs
@@ -42,7 +42,6 @@ namespace PhiClient
     public class AuthentificationPacket : Packet
     {
         public string name;
-        public int? id;
         public string hashedKey;
         public string version;
 

--- a/PhiData/RealmData.cs
+++ b/PhiData/RealmData.cs
@@ -113,7 +113,6 @@ namespace PhiClient
 
         public User ServerAddUser(string name, int id)
         {
-
             User user = new User
             {
                 id = id,


### PR DESCRIPTION
Fixes #35 by removing the requirement for clients to send their user id stored in their key file to authenticate.

Clients will also no longer store their user id in their key file.
Old key files still containing a user id are compatible as only the first line is read.